### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. First part of our GitHub Certifications program.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added 'GitHub Skills' activity to the activities list
- Includes description referencing the GitHub Certifications program
- Scheduled for Mondays and Thursdays, 3:30 PM - 4:30 PM
- Capacity for 25 participants
- Ready for student signups

## Related Issue
Resolves #6

## Testing
Students should now be able to find and sign up for the GitHub Skills activity on the school website.